### PR TITLE
Update issues_labeler.yml

### DIFF
--- a/.github/workflows/issues_labeler.yml
+++ b/.github/workflows/issues_labeler.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/issues_labeler.yml
-          enable-versioned-regex: 0
+          


### PR DESCRIPTION
# Description

Remove invalid enable-versioned-regex input from issue labeler workflow

The enable-versioned-regex input is not recognized by the github/issue-labeler action, causing the workflow to fail. This commit removes that line to fix the issue.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added a Screenshort
![image2](https://github.com/user-attachments/assets/0d7c9443-7763-49c0-aefc-daf387f2a4ab)

![image1](https://github.com/user-attachments/assets/4017e559-e42e-400c-a09d-50564d689914)

